### PR TITLE
Offset AURORA concert timer by 2 hours

### DIFF
--- a/src/event-data/event-data.js
+++ b/src/event-data/event-data.js
@@ -111,7 +111,7 @@ const eventDefinitions = {
         key: eventNames.CONCERT_GRABSEATS,
         type: eventTypes.CONCERT,
         period: 4 * 60,
-        hour: (hour) => hour % 4,
+        hour: (hour) => (2 + hour) % 4,
         minute: (minute) => 0 - minute,
     },
     [eventNames.CONCERT_STARTS]: {
@@ -119,7 +119,7 @@ const eventDefinitions = {
         key: eventNames.CONCERT_STARTS,
         type: eventTypes.CONCERT,
         period: 4 * 60,
-        hour: (hour) => hour % 4,
+        hour: (hour) => (2 + hour) % 4,
         minute: (minute) => 10 - minute,
     },
 };


### PR DESCRIPTION
Reported by Nora on the Sky Wiki Discord. After the AURORA Encore Concerts event the timer has changed.
The event now starts 2 hours after reset and repeats every 4 hours as usual.

This PR should correctly adjust the timer to match the in-game countdown. I'm going to be honest, even after this change I still don't really understand how these hour and minute functions operate. Seems to be correct though 👀