### PR TITLE
css adjustments to contributors list

### DIFF
--- a/src/components/contributor/contributors.css
+++ b/src/components/contributor/contributors.css
@@ -1,5 +1,5 @@
 h3 {
-    line-height: .6em;
+    line-height: 1em;
 }
 
 #contributors {
@@ -13,14 +13,18 @@ h3 {
 }
 
 #contributors ul {
-    display: block;
+    display: inline;
     width: 40%;
     margin: 0 auto;
     padding-bottom: .9em;
-    text-align: left;
+    text-align: center;
 }
 
 #contributors ul li {
     list-style: none;
-    margin-left: 8em;
+    margin-left: auto;
+}
+
+#contributors div {
+    margin-top: 2.5em;
 }

--- a/src/contributors.js
+++ b/src/contributors.js
@@ -11,6 +11,10 @@ const contributors = [
         name: 'Kathryn Kosey',
         url: 'https://github.com/kakosey'
     },
+    {
+        name: 'nodeMD',
+        url: 'https://github.com/nodeMD'
+    }
 ];
 
 export default contributors;


### PR DESCRIPTION
Proposal of adjusting the contributors section (https://github.com/cmstead/sky-clock/issues/8)

How the contributors section (footer) looked before:
![image](https://github.com/cmstead/sky-clock/assets/53050193/3a0c21c3-fbcf-4f92-b26a-c6ba2efeb9c0)
![image](https://github.com/cmstead/sky-clock/assets/53050193/d41ea54a-e96d-464c-9add-901b5a9277c7)

How it looks after:
![image](https://github.com/cmstead/sky-clock/assets/53050193/b26ceccf-065d-4e2b-ace0-bcd7b97a6bca)
![image](https://github.com/cmstead/sky-clock/assets/53050193/bed091f1-f0f7-43ad-a1e4-60f82c144f6f)
