### PR TITLE
fix: seconds showing as undefined

### DIFF
--- a/src/components/time/Time.js
+++ b/src/components/time/Time.js
@@ -5,5 +5,5 @@ function padTime(time) {
 }
 
 export default function render({ hour, minute, second }) {
-    return (<span className="time">{`${padTime(hour)}:${padTime(minute)}${second !== null ? (`:${padTime(second)}`) : ''}`}</span>);
+    return (<span className="time">{`${padTime(hour)}:${padTime(minute)}${second ? (`:${padTime(second)}`) : ''}`}</span>);
 }


### PR DESCRIPTION
Resolves #29 

Instead of explicitly checking for null, check for `second` which will handle both conditions